### PR TITLE
fix bug #1

### DIFF
--- a/src/org/biomart/common/constants/OutputConstants.java
+++ b/src/org/biomart/common/constants/OutputConstants.java
@@ -5,7 +5,7 @@ package org.biomart.common.constants;
  * @author jhsu
  */
 public interface OutputConstants {
-    public static final int NEWLINE = 0x0a;
+    public static final byte[] NEWLINE = { 0x0a };
     public static final int BACK_SLASH = 0x5c;
     public static final int QUOTE = 0x27;
     public static final int TAB = 0x09;


### PR DESCRIPTION
Inside `ProcessorImpl.java`, when `out.write` is invoked with only NEWLINE as argument, it gets called the `public void write(int b)` method defined by the FilterOutputStream class and not the one defined by `IframeOutputStream` which has a different signature. 
